### PR TITLE
fix: dotnet pack command --output fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build NuGet Package
-      run: dotnet pack --no-build -Version ${GITHUB_REF#refs/tags/v} --configuration Release -OutputDirectory ./artifacts
+      run: dotnet pack --no-build -Version ${GITHUB_REF#refs/tags/v} --configuration Release --output ./artifacts
 
     - name: Publish NuGet package
       run: nuget push ./artifacts/HelpDeskId.*.nupkg ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
GitHub Issue: #


## Proposed Changes

 - Build or CI related changes 


## What is the current behavior?
failed on dotnet pack command due to  wrong options

## What is the new behavior?
update option of dotnet pack cmd from -outputdirectory  to --output to work

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

